### PR TITLE
Planの一覧と詳細のページのfetchを`no-cache`に変更

### DIFF
--- a/app/allPost/[id]/page.tsx
+++ b/app/allPost/[id]/page.tsx
@@ -9,7 +9,7 @@ import { config } from "@/lib/config";
 
 async function getDetailData(id: number, host: string) {
   const res = await fetch(`${config.apiPrefix}${host}/api/plan/${id}`, {
-    cache: "no-store", //ssr
+    cache: "no-cache", //ssr
   });
   const data = await res.json();
   return data;

--- a/app/allPost/components/CourseCardCore.tsx
+++ b/app/allPost/components/CourseCardCore.tsx
@@ -5,7 +5,7 @@ import { config } from "@/lib/config";
 
 async function getAllCoursesDate(host: string) {
   const res = await fetch(`${config.apiPrefix}${host}/api/plan`, {
-    cache: "no-store", //ssr
+    cache: "no-cache", //ssr
   });
   const data = await res.json();
   return data.posts;


### PR DESCRIPTION
This pull request includes changes to the caching strategy for fetching data in two files. The `cache` option has been updated from `"no-store"` to `"no-cache"` to adjust how the server handles the cache for these requests.

Changes to caching strategy:

* `app/allPost/[id]/page.tsx`: Updated the `cache` option from `"no-store"` to `"no-cache"` in the `getDetailData` function to modify the caching behavior for fetching detailed data. ([app/allPost/[id]/page.tsxL12-R12](diffhunk://#diff-fd2e1ff641808b948b236ad5ad273a480f6a68cde4e53aac6875c84bef324189L12-R12))
* [`app/allPost/components/CourseCardCore.tsx`](diffhunk://#diff-c03e0f70d790ec8b560919ea6d86a323b81cdbb2e0591b111d1a039a0fc3f43aL8-R8): Updated the `cache` option from `"no-store"` to `"no-cache"` in the `getAllCoursesDate` function to modify the caching behavior for fetching course data.