### PR TITLE
CORSによるAPIの保護を実装

### DIFF
--- a/app/api/cors.ts
+++ b/app/api/cors.ts
@@ -1,0 +1,12 @@
+export function getCorsOrigin() {
+  if (process.env.NODE_ENV === "development") {
+    return "http://localhost:3000";
+  }
+  return process.env.NEXT_PUBLIC_VERCEL_URL || "";
+}
+
+export const corsHeaders = {
+  "Access-Control-Allow-Origin": getCorsOrigin(),
+  "Access-Control-Allow-Methods": "GET, OPTIONS", // 許可するメソッド
+  "Access-Control-Allow-Headers": "Content-Type", // 許可するリクエストヘッダー
+};

--- a/app/api/plan/route.ts
+++ b/app/api/plan/route.ts
@@ -1,5 +1,6 @@
 import prisma from "utils/prisma/prismaClient";
 import { NextResponse } from "next/server";
+import { corsHeaders } from "../cors";
 
 // Plan投稿用API
 export const POST = async (req: Request) => {
@@ -38,7 +39,10 @@ export const GET = async () => {
         },
       },
     });
-    return NextResponse.json({ message: "Success", posts });
+    return NextResponse.json(
+      { message: "Success", posts },
+      { headers: corsHeaders }
+    );
   } catch (error) {
     return NextResponse.json({ message: "Error", error }, { status: 501 });
   } finally {


### PR DESCRIPTION
- 以前他のエンジニアの方にアプリを触ってもらったときにどこからでもAPIにリクエストを送信できてしまう問題があることを指摘してもらったため、CORSによる設定を行いAPIを保護した
- 試験的に`Plan`の全件取得を行うAPIのみを保護し本番環境で確認する
- 問題がなければ他のAPIにも実装する