### PR TITLE
プランの一覧の取得と詳細の取得のfetch方法を変更

### DIFF
--- a/app/allPost/[id]/page.tsx
+++ b/app/allPost/[id]/page.tsx
@@ -9,7 +9,7 @@ import ReviewSection from "./components/ReviewSection";
 
 async function getDetailData(id: number, host: string) {
   const res = await fetch(`${config.apiPrefix}${host}/api/plan/${id}`, {
-    cache: "no-cache", //ssr
+    cache: "no-store", //ssr
   });
   const data = await res.json();
   return data;

--- a/app/allPost/components/CourseCardCore.tsx
+++ b/app/allPost/components/CourseCardCore.tsx
@@ -5,7 +5,9 @@ import { config } from "lib/config";
 
 async function getAllCoursesDate(host: string) {
   const res = await fetch(`${config.apiPrefix}${host}/api/plan`, {
-    cache: "no-cache", //ssr
+    next: {
+      revalidate: 3600, //ISRを一時間に設定
+    },
   });
   const data = await res.json();
   return data.posts;


### PR DESCRIPTION
## 現状問題となっていたこと

- 現状一覧ページの取得にある程度の時間がかかってしまうため改善したかった

## 改善に至った理由と結論

- プラン一覧ページについて
  - 履修プランの一覧ページは頻繁にユーザーが訪れると考えられる.
  - cacheを使用して高速に表示ができるかつ、定期的なrefetchが走らせたい
  - 以上の理由よりISRが最適だと考えた。
 
- プラン詳細ページについて
  - また詳細ページはユーザーが気になるもののみをクリックすると考えられる。
  - プランの作成者が編集する可能性があるためある程度のリアルタイム性は必要だと考えた
  - 以上の理由よりSSRを採用

## 疑問点
- 数日前にfetchのcacheプロパティーを`no-cache`に変更した
- 理由は以前インターンに行ったときにserver actionの記述で`no-cache`を使用しており知ったため
- Next.jsの公式ドキュメントを見ても`no-cache`に関する記述はなく現状でもわからない
- 今後調べていき判明したら追記する