### PR TITLE
プロフィールページのコンポーネント構成を変更

### DIFF
--- a/app/profile/components/LogoutButton.tsx
+++ b/app/profile/components/LogoutButton.tsx
@@ -1,0 +1,28 @@
+import useUser from "app/hooks/useUser";
+import { useRouter } from "next/navigation";
+import toast from "react-hot-toast";
+
+const LogoutButton = () => {
+  const { signOut } = useUser();
+  const router = useRouter();
+
+  const logOut = () => {
+    signOut();
+    toast.success("ログアウトしました");
+    router.push("/");
+    router.refresh();
+  };
+
+  return (
+    <div>
+      <button
+        onClick={logOut}
+        className="mt-5 bg-red-500 hover:bg-red-600 text-white px-5 py-3 duration-200 rounded-xl"
+      >
+        ログアウト
+      </button>
+    </div>
+  );
+};
+
+export default LogoutButton;

--- a/app/profile/components/LogoutButton.tsx
+++ b/app/profile/components/LogoutButton.tsx
@@ -1,9 +1,11 @@
-import useUser from "app/hooks/useUser";
 import { useRouter } from "next/navigation";
 import toast from "react-hot-toast";
 
-const LogoutButton = () => {
-  const { signOut } = useUser();
+interface LogoutButtonProps {
+  signOut: () => void;
+}
+
+const LogoutButton = ({ signOut }: LogoutButtonProps) => {
   const router = useRouter();
 
   const logOut = () => {

--- a/app/profile/components/ProfileContent.tsx
+++ b/app/profile/components/ProfileContent.tsx
@@ -1,0 +1,58 @@
+"use client";
+import { Button } from "@/components/ui/button";
+import useUser from "app/hooks/useUser";
+import Link from "next/link";
+import { ClipLoader } from "react-spinners";
+import LogoutButton from "./LogoutButton";
+import NotAllowPage from "app/components/NotAllowPage";
+
+const ProfileContent = () => {
+  const { user, isLoading, session } = useUser();
+  const id = user?.id;
+
+  if (!session) {
+    return <NotAllowPage />;
+  }
+
+  return (
+    <>
+      {isLoading ? (
+        <>
+          <p className="text-center text-lg">読み込み中・・・</p>
+          <ClipLoader color="#ff7800" size={50} className="mx-auto my-8" />
+        </>
+      ) : (
+        <>
+          <div className="flex flex-col gap-y-2 text-lg font-medium">
+            <p>ユーザー名：{user?.name}</p>
+            <p>登録メールアドレス：{user?.email}</p>
+            <p>所属学校名：{user?.university}</p>
+            <p>学部名：{user?.faculty}</p>
+            <p>学科名：{user?.department}</p>
+            <p>学年：{user?.grade}年</p>
+          </div>
+        </>
+      )}
+
+      <div>
+        <Button>
+          <Link href="/profile/edit">プロフィールを編集する</Link>
+        </Button>
+      </div>
+
+      <div className="mt-5 space-x-12">
+        <Button>
+          <Link href="/post">自分の過去のレビューを見る</Link>
+        </Button>
+      </div>
+      <div className="mt-5">
+        <button className="bg-red-500 hover:bg-red-600 text-white px-5 py-3 duration-200 rounded-xl">
+          <Link href={`/create/editplan/${id}`}>過去のプランを編集・削除</Link>
+        </button>
+      </div>
+      <LogoutButton />
+    </>
+  );
+};
+
+export default ProfileContent;

--- a/app/profile/components/ProfileContent.tsx
+++ b/app/profile/components/ProfileContent.tsx
@@ -7,7 +7,7 @@ import LogoutButton from "./LogoutButton";
 import NotAllowPage from "app/components/NotAllowPage";
 
 const ProfileContent = () => {
-  const { user, isLoading, session } = useUser();
+  const { user, isLoading, session, signOut } = useUser();
   const id = user?.id;
 
   if (!session) {
@@ -50,7 +50,7 @@ const ProfileContent = () => {
           <Link href={`/create/editplan/${id}`}>過去のプランを編集・削除</Link>
         </button>
       </div>
-      <LogoutButton />
+      <LogoutButton signOut={signOut} />
     </>
   );
 };

--- a/app/profile/edit/components/EditProfile.ts
+++ b/app/profile/edit/components/EditProfile.ts
@@ -1,0 +1,27 @@
+"use client";
+
+export const EditProfile = async (
+  name: string,
+  auth_id: string,
+  university: string,
+  faculty: string,
+  department: string,
+  grade: number
+) => {
+  const res = await fetch("/api/user/update", {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      name,
+      auth_id,
+      university,
+      faculty,
+      department,
+      grade,
+    }),
+  });
+  const data = await res.json();
+  return data;
+};

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,75 +1,11 @@
-"use client";
-import { Button } from "@/components/ui/button";
-import useUser from "../hooks/useUser";
-import { useRouter } from "next/navigation";
-import Link from "next/link";
-import toast from "react-hot-toast";
-import { ClipLoader } from "react-spinners";
-import NotAllowPage from "../components/NotAllowPage";
+import ProfileContent from "./components/ProfileContent";
 
 const ProfilePage = () => {
-  const { signOut, user, isLoading, session } = useUser();
-  const router = useRouter();
-  const id = user?.id;
-
-  const logOut = () => {
-    signOut();
-    toast.success("ログアウトしました");
-    router.push("/");
-    router.refresh();
-  };
-
-  if (!session) {
-    return <NotAllowPage />;
-  }
   return (
     <div className="mx-auto max-w-3xl lg:max-w-2xl px-4 sm:px-6 lg:px-8 pb-16 pt-20 text-center lg:pt-32">
       <h1 className="text-2xl font-bold mb-5">プロフィール画面</h1>
       <div className="bg-slate-50 rounded-xl px-4 py-4 shadow-lg ring-1 ring-gray-400">
-        {isLoading ? (
-          <>
-            <p className="text-center text-lg">読み込み中・・・</p>
-            <ClipLoader color="#ff7800" size={50} className="mx-auto my-8" />
-          </>
-        ) : (
-          <>
-            <div className="flex flex-col gap-y-2 text-lg font-medium">
-              <p>ユーザー名：{user?.name}</p>
-              <p>登録メールアドレス：{user?.email}</p>
-              <p>所属学校名：{user?.university}</p>
-              <p>学部名：{user?.faculty}</p>
-              <p>学科名：{user?.department}</p>
-              <p>学年：{user?.grade}年</p>
-            </div>
-          </>
-        )}
-
-        <div>
-          <Button>
-            <Link href="/profile/edit">プロフィールを編集する</Link>
-          </Button>
-        </div>
-
-        <div className="mt-5 space-x-12">
-          <Button>
-            <Link href="/post">自分の過去のレビューを見る</Link>
-          </Button>
-        </div>
-        <div className="mt-5">
-          <button className="bg-red-500 hover:bg-red-600 text-white px-5 py-3 duration-200 rounded-xl">
-            <Link href={`/create/editplan/${id}`}>
-              過去のプランを編集・削除
-            </Link>
-          </button>
-        </div>
-        <div>
-          <button
-            onClick={logOut}
-            className="mt-5 bg-red-500 hover:bg-red-600 text-white px-5 py-3 duration-200 rounded-xl"
-          >
-            ログアウト
-          </button>
-        </div>
+        <ProfileContent />
       </div>
     </div>
   );


### PR DESCRIPTION
## 実装意図
- issueに立てているコンポーネント構成が不適切である点を修正するため、このPRでは`/profile`に限定して修正

## 変更した点
- `page.tsxが`クライアントコンポーネントになっていたため、`ProfileContent.tsx`を作成してサーバーコンポーネント化
- また、現状のコードが大きく分けてユーザー情報を表示する部分とログアウトをする部分に分けられるためログアウト部分をさらに分けるため`LogoutButton.tsx`を作成
- `useUser`から取り出してる`signOut`関数は`ProfileContent.tsx`で取り出し、`useUser`を二重で書かないようにしました