### PR TITLE
Jestのテスト設定変更とテストコード修正

### DIFF
--- a/__test__/NotAllowPage.test.tsx
+++ b/__test__/NotAllowPage.test.tsx
@@ -1,16 +1,12 @@
-import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import NotAllowPage from "app/components/NotAllowPage";
 
-describe("NotAllowPage", () => {
-  it("renders without crashing", () => {
+// アクセス権限がないページの表示テスト
+describe("<NotAllowPage/>", () => {
+  test("アクセスできないことを示す文章が正しく表示されるかのテスト", () => {
     render(<NotAllowPage />);
-  });
-
-  it("displays the error message correctly", () => {
-    render(<NotAllowPage />);
-    const errorMessage =
-      screen.getByText(/このページにはアクセスできません！/i);
-    expect(errorMessage).toBeInTheDocument();
+    expect(
+      screen.getByText("このページにはアクセスできません！")
+    ).toBeInTheDocument();
   });
 });

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,18 +1,18 @@
-import type { Config } from 'jest'
-import nextJest from 'next/jest.js'
+import type { Config } from "jest";
+import nextJest from "next/jest.js";
 
 const createJestConfig = nextJest({
   // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
-  dir: './',
-}) 
+  dir: "./",
+});
 // Add any custom config to be passed to Jest
 const config: Config = {
-  coverageProvider: 'v8',
-  testEnvironment: 'jsdom',
+  coverageProvider: "v8",
+  testEnvironment: "jsdom",
   // Add more setup options before each test is run
-  // setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
-}
-setupFilesAfterEnv: ['<rootDir>/jest.setup.ts']
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+};
+// setupFilesAfterEnv: ['<rootDir>/jest.setup.ts']
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
-export default createJestConfig(config)
+export default createJestConfig(config);


### PR DESCRIPTION
## 変更点
- Jestの`setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],`の記述をConfig関数外に書いていたためテストファイルでtesing-librayをインポート削除したときにエラー発生
  - Config関数内に書き直すことで修正
- テストコードの日本語化
    - テストコードをあまり書いた経験がなかったが、後のことを考えたときに日本語でテスト内容を書いていた方が分かりやすいため変更
    - また`it`を使うのではなく`test`を使う例を見たのでそちらの方向に変更