### PR TITLE
全てのAPIを保護するためにリクエスト時にkeyを要求するよう変更

### DIFF
--- a/app/allPost/[id]/components/CourseReview.tsx
+++ b/app/allPost/[id]/components/CourseReview.tsx
@@ -41,6 +41,7 @@ const CourseReview = ({ id }: CourseReviewProps) => {
         }),
         headers: {
           "Content-Type": "application/json",
+          "x-api-key": process.env.NEXT_PUBLIC_API_KEY || "",
         },
       });
       if (!res.ok) {

--- a/app/allPost/[id]/components/ParticleReview.tsx
+++ b/app/allPost/[id]/components/ParticleReview.tsx
@@ -11,6 +11,8 @@ async function getReviewData(id: number, host: string) {
     `${config.apiPrefix}${host}/api/post/coursepost/${id}`,
     {
       cache: "no-store", //ssr
+      method: "GET",
+      headers: { "x-api-key": process.env.NEXT_PUBLIC_API_KEY || "" },
     }
   );
   const data = await res.json();

--- a/app/allPost/[id]/page.tsx
+++ b/app/allPost/[id]/page.tsx
@@ -10,6 +10,8 @@ import ReviewSection from "./components/ReviewSection";
 async function getDetailData(id: number, host: string) {
   const res = await fetch(`${config.apiPrefix}${host}/api/plan/${id}`, {
     cache: "no-store", //ssr
+    method: "GET",
+    headers: { "x-api-key": process.env.NEXT_PUBLIC_API_KEY || "" },
   });
   const data = await res.json();
   return data;

--- a/app/allPost/components/CourseCardCore.tsx
+++ b/app/allPost/components/CourseCardCore.tsx
@@ -8,6 +8,8 @@ async function getAllCoursesDate(host: string) {
     next: {
       revalidate: 3600, //ISRを一時間に設定
     },
+    method: "GET",
+    headers: { "x-api-key": process.env.NEXT_PUBLIC_API_KEY || "" },
   });
   const data = await res.json();
   return data.posts;

--- a/app/create/create-plan/components/CourseCreateForm.tsx
+++ b/app/create/create-plan/components/CourseCreateForm.tsx
@@ -51,6 +51,7 @@ const CourseCreateForm = ({ planId }: CourseCreateFormProps) => {
         body: JSON.stringify({ courses, planId }),
         headers: {
           "Content-Type": "application/json",
+          "x-api-key": process.env.NEXT_PUBLIC_API_KEY || "",
         },
       });
       if (!res.ok) {

--- a/app/create/editplan/[id]/components/DeleteCourse.tsx
+++ b/app/create/editplan/[id]/components/DeleteCourse.tsx
@@ -17,6 +17,7 @@ const DeleteCourse = ({ planId }: DeleteCourseProps) => {
         method: "DELETE",
         headers: {
           "Content-Type": "application/json",
+          "x-api-key": process.env.NEXT_PUBLIC_API_KEY || "",
         },
         body: JSON.stringify({ planId }),
       });

--- a/app/create/editplan/[id]/page.tsx
+++ b/app/create/editplan/[id]/page.tsx
@@ -5,6 +5,8 @@ import EditPlanCore from "./components/EditPlanCore";
 async function getDetailCourseData(id: number, host: string) {
   const res = await fetch(`${config.apiPrefix}${host}/api/plan/detail/${id}`, {
     cache: "no-store", //ssr
+    method: "GET",
+    headers: { "x-api-key": process.env.NEXT_PUBLIC_API_KEY || "" },
   });
   const data = await res.json();
   return data.plans;

--- a/app/create/page.tsx
+++ b/app/create/page.tsx
@@ -45,6 +45,7 @@ const PlanCreate = () => {
         }),
         headers: {
           "Content-Type": "application/json",
+          "x-api-key": process.env.NEXT_PUBLIC_API_KEY || "",
         },
       });
       if (!res.ok) {

--- a/app/hooks/useUser.ts
+++ b/app/hooks/useUser.ts
@@ -6,7 +6,13 @@ import { UserType } from "./types/UserType";
 import useSWR from "swr";
 
 async function fetcher(url: string) {
-  return fetch(url).then((res) => res.json());
+  const res = await fetch(url, {
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": process.env.NEXT_PUBLIC_API_KEY || "",
+    },
+  });
+  return res.json();
 }
 
 export default function useUser() {

--- a/app/post/page.tsx
+++ b/app/post/page.tsx
@@ -35,6 +35,7 @@ const AddPostPage = () => {
         method: "DELETE",
         headers: {
           "Content-Type": "application/json",
+          "x-api-key": process.env.NEXT_PUBLIC_API_KEY || "",
         },
         body: JSON.stringify({ postId }),
       });

--- a/app/profile/edit/components/EditProfile.ts
+++ b/app/profile/edit/components/EditProfile.ts
@@ -12,6 +12,7 @@ export const EditProfile = async (
     method: "PUT",
     headers: {
       "Content-Type": "application/json",
+      "x-api-key": process.env.NEXT_PUBLIC_API_KEY || "",
     },
     body: JSON.stringify({
       name,

--- a/app/profile/edit/page.tsx
+++ b/app/profile/edit/page.tsx
@@ -25,6 +25,7 @@ const EditProfile = async (
     method: "PUT",
     headers: {
       "Content-Type": "application/json",
+      "x-api-key": process.env.NEXT_PUBLIC_API_KEY || "",
     },
     body: JSON.stringify({
       name,

--- a/app/updatePlan/[id]/EditCorseList.tsx
+++ b/app/updatePlan/[id]/EditCorseList.tsx
@@ -23,6 +23,7 @@ const EditCorseList = ({ id, name, content }: EditCorseListProps) => {
         method: "DELETE",
         headers: {
           "Content-Type": "application/json",
+          "x-api-key": process.env.NEXT_PUBLIC_API_KEY || "",
         },
         body: JSON.stringify({ courseId }),
       });
@@ -54,6 +55,7 @@ const EditCorseList = ({ id, name, content }: EditCorseListProps) => {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
+          "x-api-key": process.env.NEXT_PUBLIC_API_KEY || "",
         },
         body: JSON.stringify({ courseId, name, content }),
       });

--- a/app/updatePlan/[id]/components/AddCourse.tsx
+++ b/app/updatePlan/[id]/components/AddCourse.tsx
@@ -46,6 +46,7 @@ const CourseCreateForm = ({ planId }: AddCourseProps) => {
         body: JSON.stringify({ courses, planId }),
         headers: {
           "Content-Type": "application/json",
+          "x-api-key": process.env.NEXT_PUBLIC_API_KEY || "",
         },
       });
       if (!res.ok) {

--- a/app/updatePlan/[id]/components/UpdatePageCore.tsx
+++ b/app/updatePlan/[id]/components/UpdatePageCore.tsx
@@ -45,6 +45,7 @@ const UpdatePageCore = ({
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
+          "x-api-key": process.env.NEXT_PUBLIC_API_KEY || "",
         },
         body: JSON.stringify({ id, title, content }),
       });

--- a/app/updatePlan/[id]/page.tsx
+++ b/app/updatePlan/[id]/page.tsx
@@ -3,7 +3,13 @@ import UpdatePageCore from "./components/UpdatePageCore";
 import { config } from "lib/config";
 
 async function getDetailData(id: number, host: string) {
-  const res = await fetch(`${config.apiPrefix}${host}/api/plan/update/${id}`);
+  const res = await fetch(`${config.apiPrefix}${host}/api/plan/update/${id}`, {
+    cache: "no-store", //ssr
+    method: "GET",
+    headers: {
+      "x-api-key": process.env.NEXT_PUBLIC_API_KEY || "",
+    },
+  });
   const data = await res.json();
   return data;
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(req: NextRequest) {
+  // APIへのアクセスに対してのみミドルウェアを適用
+  if (req.nextUrl.pathname.startsWith("/api")) {
+    // x-api-keyの検証
+    const apiKey = req.headers.get("x-api-key");
+    if (apiKey !== process.env.NEXT_PUBLIC_API_KEY) {
+      return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+    }
+  }
+
+  return NextResponse.next();
+}
+
+// ミドルウェアの適用範囲を指定
+export const config = {
+  matcher: "/api/:path*", // すべてのAPIエンドポイントに適用
+};


### PR DESCRIPTION
### 実装意図や考えた
- 以前他の人に触ってもらった際にAPIが保護されていないことを指摘され改善方法を模索していた
- #16 でrevertした通りCORSの設定を行うことでAPIを保護できると考えていたが、自分のCORSの理解が間違えていたためrevertした
- 再度考えたところfetchのリクエストのheaderに任意のkeyを割り当てそれを認証することでリクエストを許可することで実現できると考えた。
- 全てのAPIに保護のための記述をするのは手間かつメンテナンス性に欠けるため、`middleware.ts`を作成しapiディレクトリにある全てのファイルにルールを設定

### 主な実装方法など
- `middleware.ts`にリクエストのheaderに`x-api-key`が環境変数から読み込んだ値と一致しなければstatusで401を返すように実装
- フロントエンド側ではheaderに環境変数から読み込んだ値を付与してリクエストを送信するように設定

Postmanで動作確認を行った結果期待通りheaderに何もない状態ではリクエストが送れないことが確認できた。

<img width="400" alt="image" src="https://github.com/user-attachments/assets/026b97fc-1f07-4f70-80c7-ea3a32ed6ee1">
例：/api/planにリクエストを送信した例