### PR TITLE
ログインページのテストコード作成と、actの記述方法を変更

### DIFF
--- a/__test__/LandingSection.test.tsx
+++ b/__test__/LandingSection.test.tsx
@@ -4,26 +4,28 @@ import { mockData } from "./mock/mock_CmsData";
 
 describe("<LandingSection />", () => {
   test("LandingSectionコンポーネントが正しく表示されるかのテスト", async () => {
-    await act(async () => {
-      render(<LandingSection data={mockData} />);
-    });
+    render(<LandingSection data={mockData} />);
+
+    await act(async () => {});
 
     expect(screen.getByText(mockData.title || "")).toBeInTheDocument();
   });
 
   test("アプリケーション名がレンダリングされる", async () => {
-    await act(async () => {
-      render(<LandingSection data={mockData} />);
-    });
+    render(<LandingSection data={mockData} />);
+
+    await act(async () => {});
+
     expect(
       screen.getByText(mockData.applicationName || "")
     ).toBeInTheDocument();
   });
 
   test("各サブタイトルとテキストがレンダリングされる", async () => {
-    await act(async () => {
-      render(<LandingSection data={mockData} />);
-    });
+    render(<LandingSection data={mockData} />);
+
+    await act(async () => {});
+
     expect(screen.getByText(mockData.subTitle1 || "")).toBeInTheDocument();
     expect(screen.getByText(mockData.text1)).toBeInTheDocument();
     expect(screen.getByText(mockData.subTitle2 || "")).toBeInTheDocument();
@@ -40,14 +42,14 @@ describe("<LandingSection />", () => {
   });
 
   test("画像が正しいsrc属性でレンダリングされる", async () => {
-    await act(async () => {
-      render(<LandingSection data={mockData} />);
-    });
+    render(<LandingSection data={mockData} />);
 
     const imageElement = screen.getByAltText("Home");
     const imageElement_img1 = screen.getByAltText("Image 1");
     const imageElement_img2 = screen.getByAltText("Image 2");
     const imageElement_img3 = screen.getByAltText("Image 3");
+
+    await act(async () => {});
 
     expect(imageElement).toHaveAttribute("src");
     expect(imageElement.getAttribute("src")).toContain(

--- a/__test__/LoginPage.test.tsx
+++ b/__test__/LoginPage.test.tsx
@@ -1,0 +1,76 @@
+import { act, render, screen } from "@testing-library/react";
+import LoginPage from "app/user/login/page";
+import user from "@testing-library/user-event";
+
+// モック化したuseRouterをインポート
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+}));
+
+describe("<Page />", () => {
+  test("LoginPageコンポーネントが正しく表示されるかのテスト", async () => {
+    render(<LoginPage />);
+
+    await act(async () => {});
+
+    expect(screen.getByText("ログイン画面")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("メールアドレス")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("パスワード")).toBeInTheDocument();
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  test("メールアドレスとパスワード欄が未入力の場合、エラーメッセージが表示されるかのテスト", async () => {
+    render(<LoginPage />);
+
+    const submitButton = screen.getByRole("button");
+    await user.click(submitButton);
+
+    await act(async () => {});
+
+    expect(
+      screen.getByText("メールアドレスを入力してください")
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText("パスワードを入力してください")
+    ).toBeInTheDocument();
+  });
+
+  test("適切なメールアドレス,適切なパスワードを入力していない場合、エラーメッセージが表示されるテスト", async () => {
+    render(<LoginPage />);
+
+    const emailInput = screen.getByPlaceholderText("メールアドレス");
+    const passwordInput = screen.getByPlaceholderText("パスワード");
+    const submitButton = screen.getByRole("button");
+
+    await user.type(emailInput, "test");
+    await user.type(passwordInput, "pass");
+    await user.click(submitButton);
+
+    await act(async () => {});
+
+    expect(
+      screen.getByText("有効なメールアドレスを入力してください")
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText("パスワードは6文字以上にしてください")
+    ).toBeInTheDocument();
+  });
+
+  test("正しいメールアドレスを入力した時、ログイン成功メッセージが表示され、ルートにリダイレクトされるかのテスト", async () => {
+    render(<LoginPage />);
+
+    const emailInput = screen.getByPlaceholderText("メールアドレス");
+    const passwordInput = screen.getByPlaceholderText("パスワード");
+    const submitButton = screen.getByRole("button");
+
+    await user.type(emailInput, "adidas827068@gmail.com");
+    await user.type(passwordInput, "123456");
+    await user.click(submitButton);
+
+    await act(async () => {});
+
+    expect(screen.getByText("ログイン中・・・")).toBeInTheDocument();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.5.0",
         "@testing-library/react": "^16.0.1",
+        "@testing-library/user-event": "^14.5.2",
         "@types/jest": "^29.5.13",
         "@types/node": "^20",
         "@types/react": "^18",
@@ -2670,6 +2671,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
     "@types/jest": "^29.5.13",
     "@types/node": "^20",
     "@types/react": "^18",


### PR DESCRIPTION
### 実装意図
- テストの網羅性を向上させるために、`/app/user/login/page.tsx`のコンポーネントに対して単体テストを作成

### 実装詳細
- テストした項目を以下に示す
  - 画面に必要な要素が表示されていることの確認テスト
  - メールアドレスとパスワードが未入力の時のテスト
  - 適切なメールアドレス,パスワードの形でないものが入力された時のテスト
  - 正しくログインができた時ののテスト

### 詰まった点
- 正しくログインができた時のテストで、成功した時の処理でtoastを表示しているがtoastはDOM要素ではないため、要素の取得ができなかった。
- モックして挙動を確認できるか試したが、難しそうだったので一旦「ログイン中・・・」という文字列が出てくることを確認としてテストを通過させるようにした。
  -  しかし、テストとしては十分ではないと考えているため、アプリ側のロジックの変更などをしてログインしたことを確認した方が良いと感じた。

- actに関しては以下の記事を参考
- actでラップしなればならないというコンソールエラーが出るが、検索して簡単なアプローチでエラーを消すことができるものを見つけ、適応させた
  - https://kajiri.dev/i-ran-an-empty-act-in-react-and-the-error-disappeared