### PR TITLE
履修プラン更新ページのテストを記述

### DIFF
--- a/__test__/UpdatePage.test.tsx
+++ b/__test__/UpdatePage.test.tsx
@@ -1,0 +1,59 @@
+import { render, waitFor, screen, act } from "@testing-library/react";
+import { config } from "lib/config";
+import UpdatePage from "app/updatePlan/[id]/page";
+import { mockData } from "./mock/mock_UpdatePage";
+
+jest.mock("next/headers", () => ({
+  headers: jest.fn(() => ({
+    get: jest.fn(() => "test-host"),
+  })),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+}));
+
+global.fetch = jest.fn(); //fetch関数をモック化
+
+describe("UpdatePageコンポーネントに関するテスト", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("APIから正しくデータを取得する", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      json: jest.fn().mockResolvedValueOnce(mockData),
+    });
+
+    render(await UpdatePage({ params: { id: 1 } }));
+    await act(async () => {});
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${config.apiPrefix}test-host/api/plan/update/1`, //仮としてidが1のデータを取得する
+        expect.objectContaining({
+          cache: "no-store",
+          method: "GET",
+          headers: {
+            "x-api-key": expect.any(String),
+          },
+        })
+      );
+    });
+  });
+
+  test("UpdatePageCoreに正しいpropsを渡し、それが画面に表示されていることを確認する", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      json: jest.fn().mockResolvedValueOnce(mockData),
+    });
+
+    render(await UpdatePage({ params: { id: 1 } }));
+
+    await act(async () => {});
+
+    expect(screen.getByDisplayValue("テストタイトル")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("テスト内容")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("講座1")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("講座2")).toBeInTheDocument();
+  });
+});

--- a/__test__/mock/mock_UpdatePage.ts
+++ b/__test__/mock/mock_UpdatePage.ts
@@ -1,0 +1,9 @@
+export const mockData = {
+  title: "テストタイトル",
+  content: "テスト内容",
+  courses: [
+    { id: 1, name: "講座1", description: "説明1" },
+    { id: 2, name: "講座2", description: "説明2" },
+  ],
+  user: { name: "テストユーザー" },
+};

--- a/app/updatePlan/[id]/components/UpdatePageCore.tsx
+++ b/app/updatePlan/[id]/components/UpdatePageCore.tsx
@@ -12,7 +12,7 @@ import useUser from "app/hooks/useUser";
 import { UserType } from "app/hooks/types/UserType";
 import NotAllowPage from "app/components/NotAllowPage";
 
-interface UpdatePageCoreProps {
+export interface UpdatePageCoreProps {
   paramsId: number;
   title: string;
   content: string;


### PR DESCRIPTION
### 実装意図
- テストの網羅生を向上させるため本PRでは`app/updatePlan/[id]/page.tsx`に対してテストを記述
- fetchに関する記述があったため、fetch関数をモック化モックデータを作成

### 具体的な実装方法
- 具体的に行ったテストとして、**APIから正しくデータを取得する**ことと、**UpdatePageCoreに正しいpropsを渡し、それが画面に表示されていることを確認する**テストを作成
  - APIからデータ取得に関するテストは仮に`id=1`として`行った。
  - 画面に表示されるか確認するテストでは、fetch後にレンダリングをしモックデータとして用意したものと文字の比較を行った。

### その他
- `UpdatePageCoreProps`をテストでpropsの型指定を行いたかったため、export