### PR TITLE
履修プラン一覧画面と、詳細ページのテストを記述

### DIFF
--- a/__test__/CourseList.test.tsx
+++ b/__test__/CourseList.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import CardList from "app/allPost/components/CardList";
+import { mock_CardList } from "./mock/mock_CardList";
+
+jest.mock("next/link", () => {
+  return ({ children }: { children: React.ReactNode }) => {
+    return children;
+  };
+});
+
+describe("<CardList />", () => {
+  test("タイトルが正しくレンダリングされること", () => {
+    render(<CardList {...mock_CardList} />);
+    expect(
+      screen.getByText(`タイトル：${mock_CardList.tittle}`)
+    ).toBeInTheDocument();
+  });
+
+  test("ユーザー情報が正しくレンダリングされること", () => {
+    render(<CardList {...mock_CardList} />);
+    expect(
+      screen.getByText(
+        `作成者：${mock_CardList.user.name} / 大学名:${mock_CardList.user.university}`
+      )
+    ).toBeInTheDocument();
+  });
+
+  test("コンテンツが正しくレンダリングされること", () => {
+    render(<CardList {...mock_CardList} />);
+    expect(
+      screen.getByText(`説明：${mock_CardList.content}`)
+    ).toBeInTheDocument();
+  });
+
+  test("リンクが正しくレンダリングされること", () => {
+    render(<CardList {...mock_CardList} />);
+    expect(screen.getByText("詳細を見る")).toBeInTheDocument();
+  });
+});

--- a/__test__/CourseReview.test.tsx
+++ b/__test__/CourseReview.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import CourseReview from "app/allPost/[id]/components/CourseReview";
+import { useRouter } from "next/navigation";
+import toast from "react-hot-toast";
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+}));
+jest.mock("react-hot-toast", () => ({
+  success: jest.fn(),
+  error: jest.fn(),
+}));
+
+describe("<CourseReview />", () => {
+  const mockPush = jest.fn();
+  const mockRefresh = jest.fn();
+  const mockRouter = {
+    push: mockPush,
+    refresh: mockRefresh,
+  };
+
+  beforeEach(() => {
+    (useRouter as jest.Mock).mockReturnValue(mockRouter);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("renders the component correctly", () => {
+    render(<CourseReview id={1} auth_id="123" />);
+    expect(screen.getByText("クチコミを投稿")).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("ここに入力してください")
+    ).toBeInTheDocument();
+    expect(screen.getByText("投稿する")).toBeInTheDocument();
+  });
+
+  test("shows validation error when submitting empty form", async () => {
+    render(<CourseReview id={1} auth_id="123" />);
+    fireEvent.click(screen.getByText("投稿する"));
+    await waitFor(() => {
+      expect(screen.getByText("文字を入力してください")).toBeInTheDocument();
+    });
+  });
+
+  test("submits the form successfully", async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({}),
+      })
+    ) as jest.Mock;
+
+    render(<CourseReview id={1} auth_id="123" />);
+    fireEvent.change(screen.getByPlaceholderText("ここに入力してください"), {
+      target: { value: "Test Review" },
+    });
+    fireEvent.click(screen.getByText("投稿する"));
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("投稿しました");
+      expect(mockPush).toHaveBeenCalledWith("/allPost");
+      expect(mockRefresh).toHaveBeenCalled();
+    });
+  });
+
+  test("shows error toast when submission fails", async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: false,
+      })
+    ) as jest.Mock;
+
+    render(<CourseReview id={1} auth_id="123" />);
+    fireEvent.change(screen.getByPlaceholderText("ここに入力してください"), {
+      target: { value: "Test Review" },
+    });
+    fireEvent.click(screen.getByText("投稿する"));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("エラーが発生しました");
+    });
+  });
+
+  test("shows error toast when an exception occurs", async () => {
+    global.fetch = jest.fn(() => Promise.reject("API is down")) as jest.Mock;
+
+    render(<CourseReview id={1} auth_id="123" />);
+    fireEvent.change(screen.getByPlaceholderText("ここに入力してください"), {
+      target: { value: "Test Review" },
+    });
+    fireEvent.click(screen.getByText("投稿する"));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("投稿に失敗しました");
+    });
+  });
+});

--- a/__test__/PlanDetails.test.tsx
+++ b/__test__/PlanDetails.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import PlanDetails from "app/allPost/[id]/components/PlanDetails";
+import { mockContent, mockTitle } from "./mock/mock_PlanDetails";
+
+describe("<PlanDetails />", () => {
+  test("正しくレンダリングできるかテスト", () => {
+    render(<PlanDetails title={mockTitle} content={mockContent} />);
+  });
+
+  test("正しく履修プランタイトルが表示されているかのテスト", () => {
+    render(<PlanDetails title={mockTitle} content={mockContent} />);
+    expect(screen.getByText("・履修プラン名")).toBeInTheDocument();
+    expect(screen.getByText(mockTitle)).toBeInTheDocument();
+  });
+
+  test("正しく履修プラン内容が表示されているかのテスト", () => {
+    render(<PlanDetails title={mockTitle} content={mockContent} />);
+    expect(screen.getByText("・履修プラン内容")).toBeInTheDocument();
+    expect(screen.getByText(mockContent)).toBeInTheDocument();
+  });
+});

--- a/__test__/UserInfoCard.test.tsx
+++ b/__test__/UserInfoCard.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import UserInfoCard from "app/allPost/[id]/components/UserInfoCard";
+import { mockUser } from "./mock/mock_User";
+
+describe("<UserInfoCard />", () => {
+  test("作成者情報が正しく表示されるかのテスト", () => {
+    render(<UserInfoCard user={mockUser} />);
+
+    expect(screen.getByText("作成者情報")).toBeInTheDocument();
+    expect(
+      screen.getByText(`作成者：${mockUser.name}さん`)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(`学校名：${mockUser.university}`)
+    ).toBeInTheDocument();
+    expect(screen.getByText(`学部名：${mockUser.faculty}`)).toBeInTheDocument();
+    expect(
+      screen.getByText(`学科名：${mockUser.department}`)
+    ).toBeInTheDocument();
+    expect(screen.getByText(`学年：${mockUser.grade}年生`)).toBeInTheDocument();
+  });
+});

--- a/__test__/mock/mock_CardList.ts
+++ b/__test__/mock/mock_CardList.ts
@@ -1,0 +1,9 @@
+export const mock_CardList = {
+  id: 1,
+  tittle: "サンプルタイトル",
+  content: "サンプルコンテンツ",
+  user: {
+    name: "かめい",
+    university: "テスト大学",
+  },
+};

--- a/__test__/mock/mock_PlanDetails.ts
+++ b/__test__/mock/mock_PlanDetails.ts
@@ -1,0 +1,2 @@
+export const mockTitle = "サンプルタイトル";
+export const mockContent = "サンプル内容";

--- a/__test__/mock/mock_User.ts
+++ b/__test__/mock/mock_User.ts
@@ -1,0 +1,13 @@
+import { UserType } from "app/hooks/types/UserType";
+
+export const mockUser: UserType = {
+  name: "山田太郎",
+  university: "東京大学",
+  faculty: "工学部",
+  department: "機械工学科",
+  grade: 3,
+  id: 11111,
+  auth_id: "ffffffff-ffff-ffff-ffff-ffffffffffff",
+  email: "example.com@gmail.com",
+  posts: [],
+};

--- a/app/allPost/[id]/components/CourseReview.tsx
+++ b/app/allPost/[id]/components/CourseReview.tsx
@@ -7,7 +7,7 @@ import { SubmitHandler, useForm } from "react-hook-form";
 import toast from "react-hot-toast";
 
 interface CourseReviewProps {
-  id: number;
+  id: string;
   auth_id: string;
 }
 const CourseReview = ({ id, auth_id }: CourseReviewProps) => {

--- a/app/allPost/[id]/components/ParticleReview.tsx
+++ b/app/allPost/[id]/components/ParticleReview.tsx
@@ -4,10 +4,10 @@ import { config } from "lib/config";
 import { Review } from ".";
 
 interface ParticleReviewProps {
-  id: number;
+  id: string;
 }
 
-async function getReviewData(id: number, host: string): Promise<Review> {
+async function getReviewData(id: string, host: string): Promise<Review> {
   const res = await fetch(
     `${config.apiPrefix}${host}/api/post/coursepost/${id}`,
     {

--- a/app/allPost/[id]/components/ParticleReview.tsx
+++ b/app/allPost/[id]/components/ParticleReview.tsx
@@ -1,12 +1,13 @@
 import { headers } from "next/headers";
 import { ReviewType } from "../types/ReviewType";
 import { config } from "lib/config";
+import { Review } from ".";
 
 interface ParticleReviewProps {
   id: number;
 }
 
-async function getReviewData(id: number, host: string) {
+async function getReviewData(id: number, host: string): Promise<Review> {
   const res = await fetch(
     `${config.apiPrefix}${host}/api/post/coursepost/${id}`,
     {

--- a/app/allPost/[id]/components/ReviewSection.tsx
+++ b/app/allPost/[id]/components/ReviewSection.tsx
@@ -2,7 +2,7 @@ import CourseReview from "./CourseReview";
 import ParticleReview from "./ParticleReview";
 
 interface ReviewSectionProps {
-  id: number;
+  id: string;
   auth_id: string;
 }
 const ReviewSection = ({ id, auth_id }: ReviewSectionProps) => {

--- a/app/allPost/[id]/components/index.ts
+++ b/app/allPost/[id]/components/index.ts
@@ -1,0 +1,14 @@
+export type Review = {
+  post: [
+    {
+      id: number;
+      createdAt: string;
+      updatedAt: string;
+      title: string;
+      content: string | null;
+      published: boolean;
+      authorId: number;
+      planId: number;
+    }
+  ];
+};

--- a/app/allPost/[id]/page.tsx
+++ b/app/allPost/[id]/page.tsx
@@ -8,7 +8,7 @@ import CourseListSection from "./components/CourseListSection";
 import ReviewSection from "./components/ReviewSection";
 import useSeverUser from "app/hooks/useSeverUser";
 
-async function getDetailData(id: number, host: string) {
+async function getDetailData(id: string, host: string) {
   const res = await fetch(`${config.apiPrefix}${host}/api/plan/${id}`, {
     cache: "no-store", //ssr
     method: "GET",
@@ -18,7 +18,7 @@ async function getDetailData(id: number, host: string) {
   return data;
 }
 
-const SpecificPage = async ({ params }: { params: { id: number } }) => {
+const SpecificPage = async ({ params }: { params: { id: string } }) => {
   const host = headers().get("host");
   const CourseData = await getDetailData(params.id, host!);
   const { title, content, user, courses } = CourseData;

--- a/app/allPost/page.tsx
+++ b/app/allPost/page.tsx
@@ -1,6 +1,6 @@
 import CourseCardCore from "./components/CourseCardCore";
 
-const page = () => {
+const CoursePage = () => {
   return (
     <div className="px-10 py-4 flex flex-col justify-center">
       <p className="font-semibold text-center text-3xl">
@@ -15,4 +15,4 @@ const page = () => {
   );
 };
 
-export default page;
+export default CoursePage;

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -2,7 +2,6 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
-import { useFormStatus } from "react-dom";
 
 import { cn } from "lib/utils";
 
@@ -44,15 +43,12 @@ export interface ButtonProps
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
-    const { pending } = useFormStatus();
 
     return (
-      //pending 状態の時はローディングアニメーションを表示する
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}
-        disabled={pending}
       />
     );
   }


### PR DESCRIPTION
## 実装意図
- 以前から進めているテストコードの網羅性を向上させるため、本PRでは`/allPost`に関連するテストコードを記述
- 意図としてはこれまでと同じように正しくレンダリングができることと、期待するデーターが正しく画面に表示されることを確認した。

## 具体的な実装方法
- mockデータをmockディレクトリに作成し、テスト対象のコンポーネントにPropsで渡してレンダリングを行った。
- また`toBeInTheDocument`で期待する文字列が画面上に表示されることを確認した。

## その他
- `ParticleReview.tsx`に対してテストを作成していたが、失敗してしまうため一旦テストを書かないことにした。
  - 具体的には`getReviewData`でのfetchの処理でidがundefinedになってしまう。アプリ側のコードで undefinedの時にreturnする処理を追加したが解決しなかったため、後ほど検討することとした。