### PR TITLE
`/profle` のテストコードを作成

### DIFF
--- a/__test__/ProfileCard.test.tsx
+++ b/__test__/ProfileCard.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import ProfileCard from "app/profile/components/ProfileCard";
+import { mockProfile } from "./mock/mock_Profile";
+
+describe("<ProfileCard />", () => {
+  test("コンポーネントが正しくレンダリングされ、正しいユーザー情報が表示される", () => {
+    render(<ProfileCard data={mockProfile} />);
+
+    expect(screen.getByText("プロフィール")).toBeInTheDocument();
+    expect(screen.getByText("Test User")).toBeInTheDocument();
+    expect(screen.getByText("test@example.com")).toBeInTheDocument();
+    expect(screen.getByText("Test University")).toBeInTheDocument();
+    expect(screen.getByText("Test Faculty")).toBeInTheDocument();
+    expect(screen.getByText("Test Department")).toBeInTheDocument();
+    expect(screen.getByText("3年")).toBeInTheDocument();
+  });
+});

--- a/__test__/ProfileOptionsCard.test.tsx
+++ b/__test__/ProfileOptionsCard.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { useRouter } from "next/navigation";
 import ProfileOptionsCard from "app/profile/components/ProfileOptionsCard";
-//テス語がpassするけど、エラーが出る
 jest.mock("next/navigation", () => ({
   useRouter: jest.fn(),
 }));

--- a/__test__/ProfileOptionsCard.test.tsx
+++ b/__test__/ProfileOptionsCard.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { useRouter } from "next/navigation";
+import ProfileOptionsCard from "app/profile/components/ProfileOptionsCard";
+//テス語がpassするけど、エラーが出る
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+}));
+jest.mock("../app/login/actions.ts", () => ({
+  singOut: jest.fn(),
+}));
+
+describe("<ProfileOptionsCard />", () => {
+  const mockPush = jest.fn();
+  const mockRouter = {
+    push: mockPush,
+  };
+
+  beforeEach(() => {
+    (useRouter as jest.Mock).mockReturnValue(mockRouter);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("コンポーネントが正しくレンダリングされる", () => {
+    render(<ProfileOptionsCard id="1" />);
+    expect(screen.getByText("機能")).toBeInTheDocument();
+    expect(screen.getByText("プロフィールを編集する")).toBeInTheDocument();
+    expect(screen.getByText("自分の過去のレビューを見る")).toBeInTheDocument();
+    expect(screen.getByText("過去のプランを編集・削除")).toBeInTheDocument();
+    expect(screen.getByText("ログアウト")).toBeInTheDocument();
+  });
+
+  test("各ボタンとリンクが正しくレンダリングされる", () => {
+    render(<ProfileOptionsCard id="1" />);
+    expect(
+      screen.getByLabelText("プロフィールを編集する").closest("a")
+    ).toHaveAttribute("href", "/profile/edit");
+    expect(
+      screen.getByLabelText("自分の過去のレビューを見る").closest("a")
+    ).toHaveAttribute("href", "/post");
+    expect(
+      screen.getByLabelText("過去のプランを編集・削除").closest("a")
+    ).toHaveAttribute("href", "/create/editplan/1");
+  });
+});

--- a/__test__/mock/mock_Profile.ts
+++ b/__test__/mock/mock_Profile.ts
@@ -1,0 +1,12 @@
+import { Profile } from "app/profile/components";
+
+export const mockProfile: Profile = {
+  name: "Test User",
+  email: "test@example.com",
+  university: "Test University",
+  faculty: "Test Faculty",
+  department: "Test Department",
+  grade: 3,
+  id: 0,
+  auth_id: "ffffff",
+};

--- a/app/components/layout/Modal/HamburgerMenu.tsx
+++ b/app/components/layout/Modal/HamburgerMenu.tsx
@@ -8,7 +8,12 @@ const HamburgerMenu = ({ sessionId }: { sessionId: string | undefined }) => {
   const [isOpen, setOpen] = useState(false);
   return (
     <div className="block lg:hidden">
-      <Hamburger toggled={isOpen} toggle={setOpen} size={30} />
+      <Hamburger
+        toggled={isOpen}
+        toggle={setOpen}
+        size={30}
+        label="メニューを開く"
+      />
       <ProfileDrawer
         isOpen={isOpen}
         onClose={() => setOpen(false)}


### PR DESCRIPTION
### 実装意図
- このPRでは`/profile`にフォーカスしてテストコードを記述した。

### 実装内容
- 主に他のテストコードと違いはないが、正しくレンダリングされることやレンダリング後に期待した文字が画面に表示されていることを確認することを実施した。

### その他
- #33 でPRを作成したときにGithub Actionsの不具合でmergeができなかったので再度PRを作り直した。