### PR TITLE
Supabaseのストレージに画像をアップロードするページを作成

### DIFF
--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -15,6 +15,7 @@ env:
   MICROCMS_API_DOMAIN: ${{secrets.MICROCMS_API_DOMAIN}}
   DATABASE_URL: ${{secrets.DATABASE_URL}}
   API_PREFIX: ${{secrets.API_PREFIX}}
+  SUPABASE_DOMAIN: ${{secrets.SUPABASE_DOMAIN}}
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.cursor

--- a/app/create/upload/components/ImageUpload.tsx
+++ b/app/create/upload/components/ImageUpload.tsx
@@ -57,7 +57,6 @@ export function ImageUpload() {
 
         toast.success("画像をアップロードしました");
       } catch (error) {
-        console.error("Error uploading image: ", error);
         toast.error("画像のアップロードに失敗しました");
       } finally {
         setUploading(false);

--- a/app/create/upload/components/ImageUpload.tsx
+++ b/app/create/upload/components/ImageUpload.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/card";
 import Image from "next/image";
 import toast from "react-hot-toast";
+import { v4 as uuidv4 } from "uuid";
 import { createClient } from "utils/supabase/client";
 
 export function ImageUpload() {
@@ -31,7 +32,7 @@ export function ImageUpload() {
         }
 
         const fileExt = file.name.split(".").pop();
-        const fileName = `upload-${Math.random()}.${fileExt}`;
+        const fileName = `upload-${uuidv4()}.${fileExt}`;
         const filePath = fileName;
 
         // 画像をアップロード

--- a/app/create/upload/components/ImageUpload.tsx
+++ b/app/create/upload/components/ImageUpload.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useDropzone } from "react-dropzone";
+import { Loader2, Upload } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import Image from "next/image";
+import toast from "react-hot-toast";
+import { createClient } from "utils/supabase/client";
+
+export function ImageUpload() {
+  const [uploading, setUploading] = useState(false);
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+
+  const supabase = createClient();
+
+  const onDrop = useCallback(
+    async (acceptedFiles: File[]) => {
+      try {
+        setUploading(true);
+        const file = acceptedFiles[0];
+
+        if (!file) {
+          throw new Error("ファイルを選択してください");
+        }
+
+        const fileExt = file.name.split(".").pop();
+        const fileName = `upload-${Math.random()}.${fileExt}`;
+        const filePath = fileName;
+
+        // 画像をアップロード
+        const { error: uploadError } = await supabase.storage
+          .from("avatars")
+          .upload(filePath, file);
+
+        if (uploadError) {
+          throw uploadError;
+        }
+
+        const fetchImageUrl = async (path: string) => {
+          try {
+            const { data, error } = await supabase.storage
+              .from("avatars")
+              .download(path);
+            if (error) throw error;
+            return URL.createObjectURL(data);
+          } catch (error) {
+            console.error("Error downloading image: ", error);
+            toast.error("画像の取得に失敗しました");
+            return null;
+          }
+        };
+
+        const url = await fetchImageUrl(filePath);
+        setImageUrl(url);
+
+        toast.success("画像をアップロードしました");
+      } catch (error) {
+        console.error("Error uploading image: ", error);
+        toast.error("画像のアップロードに失敗しました");
+      } finally {
+        setUploading(false);
+      }
+    },
+    [supabase]
+  );
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop,
+    accept: {
+      "image/*": [".jpeg", ".jpg", ".png"],
+    },
+    maxFiles: 1,
+    maxSize: 1024 * 1024, //サイズは1MBまで
+  });
+
+  return (
+    <Card className="w-full max-w-md mx-auto">
+      <CardHeader>
+        <CardTitle>画像アップロード</CardTitle>
+        <CardDescription>
+          画像をドラッグ&ドロップするか、クリックして選択してください
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div
+          {...getRootProps()}
+          className={`
+            border-2 border-dashed rounded-lg p-8
+            text-center cursor-pointer transition-colors
+            ${
+              isDragActive
+                ? "border-primary bg-primary/10"
+                : "border-muted-foreground/25"
+            }
+          `}
+        >
+          <input {...getInputProps()} />
+          {uploading ? (
+            <div className="flex flex-col items-center gap-2">
+              <Loader2 className="h-8 w-8 animate-spin text-primary" />
+              <p>アップロード中...</p>
+            </div>
+          ) : (
+            <div className="flex flex-col items-center gap-2">
+              <Upload className="h-8 w-8 text-muted-foreground" />
+              <p className="text-sm text-muted-foreground">
+                {isDragActive
+                  ? "ドロップしてアップロード"
+                  : "クリックまたはドラッグ&ドロップ"}
+              </p>
+            </div>
+          )}
+        </div>
+
+        {imageUrl && (
+          <div className="space-y-2">
+            <p className="text-sm font-medium">アップロード完了</p>
+            <div className="aspect-video relative rounded-lg overflow-hidden bg-muted">
+              <Image
+                src={imageUrl}
+                alt="Uploaded"
+                className="object-cover"
+                width={500}
+                height={300}
+              />
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/create/upload/components/ImageUpload.tsx
+++ b/app/create/upload/components/ImageUpload.tsx
@@ -43,21 +43,16 @@ export function ImageUpload() {
           throw uploadError;
         }
 
-        const fetchImageUrl = async (path: string) => {
-          try {
-            const { data, error } = await supabase.storage
-              .from("avatars")
-              .download(path);
-            if (error) throw error;
-            return URL.createObjectURL(data);
-          } catch (error) {
-            console.error("Error downloading image: ", error);
-            toast.error("画像の取得に失敗しました");
-            return null;
-          }
-        };
+        const { data, error } = await supabase.storage
+          .from("avatars")
+          .createSignedUrl(filePath, 600); // 10分間有効
 
-        const url = await fetchImageUrl(filePath);
+        if (error) {
+          toast.error("画像の取得に失敗しました");
+          return;
+        }
+
+        const url = data.signedUrl;
         setImageUrl(url);
 
         toast.success("画像をアップロードしました");

--- a/app/create/upload/page.tsx
+++ b/app/create/upload/page.tsx
@@ -1,0 +1,11 @@
+import { ImageUpload } from "./components/ImageUpload";
+
+const UploadImgPage = () => {
+  return (
+    <div className="container py-10">
+      <ImageUpload />
+    </div>
+  );
+};
+
+export default UploadImgPage;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,10 +1,11 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-    images: {
-        domains: ['images.microcms-assets.io'], // microCMSホスト名を追加
-    },
+  images: {
+    domains: [
+      "images.microcms-assets.io",
+      process.env.SUPABASE_DOMAIN, // 環境変数からSupabaseのドメインを取得
+    ],
+  },
 };
 
-
 export default nextConfig;
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "swr": "^2.2.5",
         "tailwind-merge": "^2.3.0",
         "tailwindcss-animate": "^1.0.7",
+        "uuidv4": "^6.2.13",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -3283,6 +3284,12 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -10829,6 +10836,26 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/uuidv4": {
+      "version": "6.2.13",
+      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
+      "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "8.3.4",
+        "uuid": "8.3.2"
+      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "next": "14.2.21",
         "react": "^18",
         "react-dom": "^18",
+        "react-dropzone": "^14.3.5",
         "react-hook-form": "^7.51.0",
         "react-hot-toast": "^2.4.1",
         "react-icons": "^5.0.1",
@@ -3891,6 +3892,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/attr-accept": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.17",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.17.tgz",
@@ -5817,6 +5827,18 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/file-selector": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
+      "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/fill-range": {
@@ -9249,7 +9271,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -9338,6 +9359,23 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-dropzone": {
+      "version": "14.3.5",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.3.5.tgz",
+      "integrity": "sha512-9nDUaEEpqZLOz5v5SUcFA0CjM4vq8YbqO0WRls+EYT7+DvxUdzDPKNCPLqGfj3YL9MsniCLCD4RFA6M95V6KMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "attr-accept": "^2.2.4",
+        "file-selector": "^2.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8 || 18.0.0"
+      }
+    },
     "node_modules/react-hook-form": {
       "version": "7.51.0",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.51.0.tgz",
@@ -9379,8 +9417,7 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-remove-scroll": {
       "version": "2.5.5",
@@ -10532,9 +10569,10 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "swr": "^2.2.5",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
+    "uuidv4": "^6.2.13",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "next": "14.2.21",
     "react": "^18",
     "react-dom": "^18",
+    "react-dropzone": "^14.3.5",
     "react-hook-form": "^7.51.0",
     "react-hot-toast": "^2.4.1",
     "react-icons": "^5.0.1",


### PR DESCRIPTION
### 実装意図
現在の実装では履修している授業名をフォームにユーザーが1つずつ入力する形となっているため、これを自動化するために入力された画像から授業名を取得し自動で入力させる機能を実装するために、まずはストレージに画像をアップロードする機能を作成したかった。

### 実装内容
- Supabase Storage を利用して画像をアップロードできる機能を追加
- `react-dropzone` を使用し、ドラッグ&ドロップによる画像アップロードを実装
- アップロード後に画像のプレビューを表示
- 画像の一時的な署名付きURLを取得し、Next.js の `next.config.mjs` に Supabase のドメインを追加
- `.github/workflows/frontend_ci.yml` に `SUPABASE_DOMAIN` の環境変数を追加
- uuidのv4を使用して画像ファイル名をランダム化し衝突を回避

### その他
- 画像の最大サイズを 1MB に制限。理由としてはSupabaseのストレージの無料枠が1GBであり節約するため。サービスの成長に対応してAWSのS3などに移行するか検討。
- 対応フォーマットは `.jpeg`, `.jpg`, `.png`
- エラーハンドリングを追加し、アップロード失敗時にユーザーに通知

### 画面キャプチャ
| 画像添付前 |
| --- |
| ![image](https://github.com/user-attachments/assets/2bb3f7d3-030f-4bfb-84b7-0166cb62dd86) |
---
| 画像投稿後 |
| --- |
| ![image](https://github.com/user-attachments/assets/70b12b9c-ff2b-452c-aa44-fc6debdb60e9) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a drag-and-drop image uploader with visual feedback and file previews, supporting JPEG, JPG, and PNG files up to 1MB.
  - Added a dedicated upload page integrating the image uploader for a seamless user experience.

- **Chores**
  - Enhanced image serving configuration to support an additional domain via environment settings.
  - Integrated a new dependency to streamline file upload handling.
  - Added a new environment variable for dynamic domain configuration in the CI workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->